### PR TITLE
Fix Wi-Fi/Bluetooth toggle shifting on L2 pages

### DIFF
--- a/Themes/BetterControl11/README.md
+++ b/Themes/BetterControl11/README.md
@@ -230,6 +230,10 @@ controlStyles:
   - target: Windows.UI.Xaml.Controls.ContentPresenter#PageHeader
     styles:
       - Background:=transparent
+  - target: ContentControl#PageHeaderContentControl
+    styles:
+      - Width=64
+      - // Prevents Wi-Fi/Bluetooth subpage switches from being displaced from the right edge
   - target: Windows.UI.Xaml.Controls.Button#PlayPauseButton > Windows.UI.Xaml.Controls.ContentPresenter#ContentPresenter
     styles:
       - Margin=-22,0


### PR DESCRIPTION
Added HorizontalAlignment=Stretch to ContentPresenter#PageHeader to ensure the header always takes full width, keeping the on/off toggle pinned to the right edge consistently.
<img width="487" height="512" alt="Screenshot 2026-06-13 181357" src="https://github.com/user-attachments/assets/7374937c-6333-41fd-85d8-e4a98ada7abc" />
