### PR TITLE
Update FrostyGlass theme styling to use WindhawkBlur on notification center and fix taskbar's apps hover flyout issue

### DIFF
--- a/Themes/FrostyGlass/README.md
+++ b/Themes/FrostyGlass/README.md
@@ -56,7 +56,6 @@ The theme styles can also be imported manually. To do that, follow these steps:
 <summary>Content to import (click to expand)</summary>
 
 ```yaml
-theme: ''
 styleConstants:
   - Background=<WindhawkBlur BlurAmount="20" TintColor="{ThemeResource SystemChromeDarkColor}" TintOpacity="0.15" />
   - BorderBrush2=<LinearGradientBrush StartPoint="0,0" EndPoint="0,1"><GradientStop Color="{ThemeResource SystemChromeHighColor}" Offset="0.0" /><GradientStop Color="{ThemeResource SystemChromeLowColor}" Offset="0.25" /><GradientStop Color="{ThemeResource SystemChromeHighColor}" Offset="1" /></LinearGradientBrush>

--- a/Themes/FrostyGlass/README.md
+++ b/Themes/FrostyGlass/README.md
@@ -7,7 +7,7 @@ A refined, translucent "Frosty" experience for the Windows 11 Notification Cente
 [![Windhawk](https://img.shields.io/badge/Requires-Windhawk-blue?style=flat-square)](https://windhawk.net/)
 [![Style](https://img.shields.io/badge/Style-Frosty_Glass-lightgrey?style=flat-square)](#)
 
-This configuration provides a modern **Frosty Glass** aesthetic for your Notification Center, Calendar, and Control Center. It utilizes custom translucent `AcrylicBrush` effects to create a soft, blurred interface that feels perfectly integrated with the desktop environment.
+This configuration provides a modern **Frosty Glass** aesthetic for your Notification Center, Calendar, and Control Center. It utilizes custom translucent `WindhawkBlur` effects to create a soft, blurred interface that feels perfectly integrated with the desktop environment.
 
 ## 📸 Showcase
 
@@ -56,8 +56,9 @@ The theme styles can also be imported manually. To do that, follow these steps:
 <summary>Content to import (click to expand)</summary>
 
 ```yaml
+theme: ''
 styleConstants:
-  - Background=<AcrylicBrush TintColor="#1000000F"/>
+  - Background=<WindhawkBlur BlurAmount="20" TintColor="{ThemeResource SystemChromeDarkColor}" TintOpacity="0.15" />
   - BorderBrush2=<LinearGradientBrush StartPoint="0,0" EndPoint="0,1"><GradientStop Color="{ThemeResource SystemChromeHighColor}" Offset="0.0" /><GradientStop Color="{ThemeResource SystemChromeLowColor}" Offset="0.25" /><GradientStop Color="{ThemeResource SystemChromeHighColor}" Offset="1" /></LinearGradientBrush>
   - BorderThickness=1
   - CornerRadius=10
@@ -143,6 +144,7 @@ controlStyles:
       - BorderBrush:=$BorderBrush
       - BorderThinkness:=$BorderThickness
       - Background:=$Background
+      - CornerRadius:=$CornerRadius
   - target: Border#WADFeatureFooter
     styles:
       - BorderBrush:=Transparent
@@ -159,19 +161,15 @@ controlStyles:
   - target: JumpViewUI.JumpListListViewItem > Grid#LayoutRoot > Border#BackgroundBorder
     styles:
       - CornerRadius:=4.5
+      - Margin=4,0,4,0
   - target: JumpViewUI.SystemItemListViewItem > Grid#LayoutRoot > Border#BackgroundBorder
     styles:
       - CornerRadius:=4.5
+      - Margin=4,0,4,0
   - target: Grid#NotificationCenterGrid
     styles:
       - VerticalAlignment:=2
   - target: Border#ToastBackgroundBorder2
-    styles:
-      - Background:=$Background
-      - BorderBrush:=$BorderBrush
-      - BorderThickness:=$BorderThickness
-      - CornerRadius:=$CornerRadius
-  - target: Border#ToastBackgroundBorder
     styles:
       - Background:=$Background
       - BorderBrush:=$BorderBrush
@@ -223,6 +221,12 @@ controlStyles:
   - target: ContentPresenter#PageContent
     styles:
       - Background:=Transparent
+  - target: Windows.UI.Xaml.Controls.Border#ToastBackgroundBorder
+    styles:
+      - Background:=$Background
+      - BorderBrush:=$BorderBrush
+      - BorderThickness:=$BorderThickness
+      - CornerRadius:=$CornerRadius
   - target: Windows.UI.Xaml.Controls.Grid > Windows.UI.Xaml.Controls.Border#ItemOpaquePlating
     styles:
       - CornerRadius:=7
@@ -250,13 +254,16 @@ controlStyles:
       - BorderThickness:=$BorderThickness
       - BorderBrush:=$BorderBrush
       - CornerRadius:=$CornerRadius
-      - Margin=-4.5,-2,-4.5,-2
-      - Height=Auto
-  - target: Windows.UI.Xaml.Controls.ScrollViewer#JumpListScroller
+  - target: ScrollViewer#JumpListScroller
     styles:
-      - Margin=-2
+      - Margin=0,-2,0,-2
   - target: Windows.UI.Xaml.Controls.Grid#SystemItemsContainer > Windows.UI.Xaml.Controls.Border > JumpViewUI.SystemItemListView#SystemItemList
     styles:
       - Margin:=0,3,0,0
+themeResourceVariables:
+  - ''
+resourceVariables:
+  - variableKey: ''
+    value: ''
 ```
 </details>

--- a/Themes/FrostyGlass/README.md
+++ b/Themes/FrostyGlass/README.md
@@ -35,7 +35,7 @@ Complete the look across your entire UI! Check out my other Frosty Glass styling
 
 A huge thank you to [Ramen Software](https://github.com/ramensoftware) for creating Windhawk. This configuration was heavily inspired by the official [Windows 11 Notification Center Styling Guide](https://github.com/ramensoftware/windows-11-notification-center-styling-guide) and the Windhawk modding community.
 
-## Theme selection
+## 🎚️ Theme selection
 
 The theme is integrated into the mod and can be selected directly from the mod's
 settings:
@@ -44,7 +44,7 @@ settings:
 * Go to the "Settings" tab.
 * Select the theme and save the settings.
 
-## Manual installation
+## 📦 Manual installation
 
 The theme styles can also be imported manually. To do that, follow these steps:
 

--- a/Themes/FrostyGlass/README.md
+++ b/Themes/FrostyGlass/README.md
@@ -261,10 +261,5 @@ controlStyles:
   - target: Windows.UI.Xaml.Controls.Grid#SystemItemsContainer > Windows.UI.Xaml.Controls.Border > JumpViewUI.SystemItemListView#SystemItemList
     styles:
       - Margin:=0,3,0,0
-themeResourceVariables:
-  - ''
-resourceVariables:
-  - variableKey: ''
-    value: ''
 ```
 </details>

--- a/Themes/FrostyGlass/README.md
+++ b/Themes/FrostyGlass/README.md
@@ -233,6 +233,7 @@ controlStyles:
       - Visibility=0
       - BorderBrush:=$BorderBrush
       - BorderThickness:=$BorderThickness
+      - Margin=4,0,4,1
   - target: Windows.UI.Xaml.Controls.ListViewItem
     styles:
       - Margin=0,0,0,3


### PR DESCRIPTION
- Fixed layout/rendering bug affecting app-specific hover panels on the taskbar.
- Replaced `AcrylicBrush` with `WindhawkBlur` for full visual consistency across mods.
- Updated README to reflect blur setup and configuration details.

Before: 
<img width="397" height="485" alt="image" src="https://github.com/user-attachments/assets/97e0f6ed-46a4-41ef-84d2-64551ea4f16b" />

After (now fixed):
<img width="1196" height="805" alt="image" src="https://github.com/user-attachments/assets/914b9718-b7b7-45c1-a0d2-d73cd2f40bec" />